### PR TITLE
support file inclusion in env and service attributes

### DIFF
--- a/examples/common-attributes/test/includeFile.yml
+++ b/examples/common-attributes/test/includeFile.yml
@@ -1,0 +1,2 @@
+default:
+  includeGlobal: includeGlobalValue

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -1,0 +1,1 @@
+workPath: ../examples

--- a/examples/env/prod-dc1/attributes/test.yml
+++ b/examples/env/prod-dc1/attributes/test.yml
@@ -1,0 +1,6 @@
+include:
+  - test.includeFile
+  - env:prod-dc2:test.includeFile
+
+default:
+  attribute: attributeValue

--- a/examples/env/prod-dc1/services/test-service/attributes/test.yml
+++ b/examples/env/prod-dc1/services/test-service/attributes/test.yml
@@ -1,0 +1,4 @@
+include:
+  - test.includeFile
+  - env:prod-dc2:test.includeFile
+  - env::test.includeFile

--- a/work/env_test.go
+++ b/work/env_test.go
@@ -1,0 +1,39 @@
+package work
+
+import (
+	"testing"
+
+	"github.com/blablacar/ggn/ggn"
+)
+
+func itemInSlice(a string, s []string) bool {
+	for _, x := range s {
+		if a == x {
+			return true
+		}
+	}
+	return false
+}
+
+func TestAddEnvIncludeFiles(t *testing.T) {
+	ggn.Home.Config.WorkPath = "../examples"
+	env := Env{}
+	files := []string{"../examples/env/prod-dc1/attributes/test.yml"}
+	files, err := env.addIncludeFiles(files)
+	if err != nil {
+		t.Logf("addIncludeFiles returned an error : %v", err)
+		t.Fail()
+	}
+	for _, includeFile := range []string{
+		"../examples/common-attributes/test/includeFile.yml",
+		"../examples/env/prod-dc2/common-attributes/test/includeFile.yml",
+	} {
+		if !itemInSlice(includeFile, files) {
+			t.Logf("File not included : %v", includeFile)
+			for _, f := range files {
+				t.Log(f)
+			}
+			t.Fail()
+		}
+	}
+}

--- a/work/service_test.go
+++ b/work/service_test.go
@@ -1,0 +1,27 @@
+package work
+
+import "testing"
+
+func TestAddServiceIncludeFiles(t *testing.T) {
+	service := Service{}
+	service.env.path = "../examples/env/prod-dc1"
+	files := []string{"../examples/env/prod-dc1/services/test-service/attributes/test.yml"}
+	files, err := service.addIncludeFiles(files)
+	if err != nil {
+		t.Logf("addIncludeFiles returned an error : %v", err)
+		t.Fail()
+	}
+	for _, includeFile := range []string{
+		"../examples/common-attributes/test/includeFile.yml",
+		"../examples/env/prod-dc2/common-attributes/test/includeFile.yml",
+		"../examples/env/prod-dc1/common-attributes/test/includeFile.yml",
+	} {
+		if !itemInSlice(includeFile, files) {
+			t.Logf("File not included : %v", includeFile)
+			for _, f := range files {
+				t.Log(f)
+			}
+			t.Fail()
+		}
+	}
+}

--- a/work/spec.go
+++ b/work/spec.go
@@ -6,6 +6,7 @@ import (
 
 const PATH_ATTRIBUTES = "/attributes"
 const PATH_TEMPLATES = "/templates"
+const PATH_COMMON_ATTRIBUTES = "/common-attributes"
 
 const ACTIVE_ACTIVE = "active"
 const SUB_RUNNING = "running"


### PR DESCRIPTION
fixes #52 
fixes #60

inclusion should be in the form of an "include" key containing a list of includes : 
```
include:
  - env:prod-dc1:some.config
  - env::some.config.from.same.environment
  - some.global.config
```
when omitting the env field like in `env::some.config` the current environment is used

* `env:prod-dc1:some.config` leads to `/env/prod-dc1/common-attributes/some/config.yml`
* `env::some.config.from.same.environment` leads to `common-attributes/some/same/environment.yml` of the same environment
* `some.global.config` leads to `/common-attributes/some/global/config.yml`