### PR TITLE
Service dependency against a minimal ggn version

### DIFF
--- a/commands/ggn.go
+++ b/commands/ggn.go
@@ -17,14 +17,10 @@ import (
 
 const FLEET_SUPPORTED_VERSION = "0.11.5"
 
-var CommitHash string
-var GgnVersion string
-var BuildDate string
-
 func Execute(commitHash string, ggnVersion string, buildDate string) {
-	CommitHash = commitHash
-	GgnVersion = ggnVersion
-	BuildDate = buildDate
+	ggn.CommitHash = commitHash
+	ggn.GgnVersion = ggnVersion
+	ggn.BuildDate = buildDate
 
 	checkFleetVersion()
 

--- a/commands/version.go
+++ b/commands/version.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/blablacar/ggn/ggn"
 	"github.com/spf13/cobra"
 )
 
@@ -13,12 +14,12 @@ var versionCmd = &cobra.Command{
 	Long:  `Print the version number of cnt`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Print("ggn\n\n")
-		fmt.Printf("version    : %s\n", GgnVersion)
-		if BuildDate != "" {
-			fmt.Printf("build date : %s\n", BuildDate)
+		fmt.Printf("version    : %s\n", ggn.GgnVersion)
+		if ggn.BuildDate != "" {
+			fmt.Printf("build date : %s\n", ggn.BuildDate)
 		}
-		if CommitHash != "" {
-			fmt.Printf("CommitHash : %s\n", CommitHash)
+		if ggn.CommitHash != "" {
+			fmt.Printf("CommitHash : %s\n", ggn.CommitHash)
 		}
 		os.Exit(0)
 	},

--- a/ggn/context.go
+++ b/ggn/context.go
@@ -6,6 +6,10 @@ import (
 
 var Home HomeStruct
 
+var CommitHash string
+var GgnVersion string
+var BuildDate string
+
 func GetUserAndHost() string {
 	user := os.Getenv("USER")
 	if Home.Config.User != "" {

--- a/work/service-generate.go
+++ b/work/service-generate.go
@@ -9,6 +9,7 @@ import (
 	"github.com/appc/spec/schema"
 	"github.com/blablacar/dgr/bin-dgr/common"
 	"github.com/blablacar/dgr/bin-templater/template"
+	"github.com/blablacar/ggn/ggn"
 	"github.com/n0rad/go-erlog/errs"
 	"github.com/n0rad/go-erlog/logs"
 )
@@ -36,6 +37,16 @@ func (s *Service) Generate() error {
 		}
 	}
 
+	if len(s.manifest.GgnMinimalVersion) > 0 {
+		var currentVersion = common.Version(ggn.GgnVersion)
+		logs.WithField("version", s.manifest.GgnMinimalVersion).Debug("Found ggn minimal version")
+		if s.manifest.GgnMinimalVersion.GreaterThan(currentVersion) {
+			logs.WithFields(s.fields).
+				WithField("ggn-minimalversion", s.manifest.GgnMinimalVersion).
+				WithField("ggn-version", currentVersion).
+				Fatal("You don't use the minimal required version of ggn for this service")
+		}
+	}
 	if len(s.nodesAsJsonMap) == 0 {
 		logs.WithFields(s.fields).Fatal("No node to process in manifest")
 		return nil

--- a/work/service-generate.go
+++ b/work/service-generate.go
@@ -42,8 +42,8 @@ func (s *Service) Generate() error {
 		logs.WithField("version", s.manifest.GgnMinimalVersion).Debug("Found ggn minimal version")
 		if s.manifest.GgnMinimalVersion.GreaterThan(currentVersion) {
 			logs.WithFields(s.fields).
-				WithField("ggn-minimalversion", s.manifest.GgnMinimalVersion).
-				WithField("ggn-version", currentVersion).
+				WithField("minimalversion", s.manifest.GgnMinimalVersion).
+				WithField("version", currentVersion).
 				Fatal("You don't use the minimal required version of ggn for this service")
 		}
 	}

--- a/work/spec.go
+++ b/work/spec.go
@@ -42,6 +42,7 @@ type HookInfo struct {
 }
 
 type ServiceManifest struct {
+	GgnMinimalVersion common.Version      `yaml:"ggnminimalversion"`
 	ConcurrentUpdater int                 `yaml:"concurrentUpdater"`
 	Containers        []common.ACFullname `yaml:"containers"`
 	ExecStartPre      []string            `yaml:"execStartPre"`

--- a/work/spec.go
+++ b/work/spec.go
@@ -42,7 +42,7 @@ type HookInfo struct {
 }
 
 type ServiceManifest struct {
-	GgnMinimalVersion common.Version      `yaml:"ggnminimalversion"`
+	GgnMinimalVersion common.Version      `yaml:"ggnMinimalVersion"`
 	ConcurrentUpdater int                 `yaml:"concurrentUpdater"`
 	Containers        []common.ACFullname `yaml:"containers"`
 	ExecStartPre      []string            `yaml:"execStartPre"`


### PR DESCRIPTION
If a service declares a dependency against a minimal version of ggn, unit file generation for this service ill be blocked if ggn doesn't fullfill version requirement.
This allow to safely upgrade service manifest and prevent service operation with uncompatible ggn versions.