### PR TITLE
Fix for feature "expose all notes manifest attributes in '.service_nodes'"

### DIFF
--- a/work/spec.go
+++ b/work/spec.go
@@ -42,12 +42,13 @@ type HookInfo struct {
 }
 
 type ServiceManifest struct {
-	GgnMinimalVersion common.Version      `yaml:"ggnMinimalVersion"`
-	ConcurrentUpdater int                 `yaml:"concurrentUpdater"`
-	Containers        []common.ACFullname `yaml:"containers"`
-	ExecStartPre      []string            `yaml:"execStartPre"`
-	ExecStart         []string            `yaml:"execStart"`
-	Nodes             interface{}         `yaml:"nodes"`
+	ExposeNodesInUnitEnv bool                `yaml:"exposeNodesInUnitEnv"`
+	GgnMinimalVersion    common.Version      `yaml:"ggnMinimalVersion"`
+	ConcurrentUpdater    int                 `yaml:"concurrentUpdater"`
+	Containers           []common.ACFullname `yaml:"containers"`
+	ExecStartPre         []string            `yaml:"execStartPre"`
+	ExecStart            []string            `yaml:"execStart"`
+	Nodes                interface{}         `yaml:"nodes"`
 }
 
 type UnitType int

--- a/work/unit-generate.go
+++ b/work/unit-generate.go
@@ -35,7 +35,9 @@ func (u *Unit) Generate(tmpl *template.Templating) error {
 	}
 	data["aciList"] = aciList
 	data["acis"] = acis
-	data["service_nodes"] = u.Service.nodesAsJsonMap
+	if u.Service.manifest.ExposeNodesInUnitEnv {
+		data["service_nodes"] = u.Service.nodesAsJsonMap
+	}
 
 	out, err := json.Marshal(data)
 	if err != nil {


### PR DESCRIPTION
This feature is very usefull but cause problems with large services.
Unit's files get too big and service start could fail because of that.

This PR aims to add a new yaml property 'exposeNodesInUnitEnv' as boolean
to make '.service_nodes' optional.

Set to 'true', service nodes will be exposed.
Set to 'false' (or not set), they won't