### PR TITLE
Fix for OS X folks

### DIFF
--- a/gomake
+++ b/gomake
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -efo pipefail # TODO u
 
  : ${target_name:=dist}


### PR DESCRIPTION
Os X people often have a bash with color support on /bin/bash.
Let's use whatever bash the user has first in it's $PATH