### PR TITLE
Fleet v1.0.0 compatibility

### DIFF
--- a/work/env-check.go
+++ b/work/env-check.go
@@ -18,7 +18,7 @@ func (e Env) Check() {
 
 	//	e.Generate()
 
-	//	units, _, err := e.RunFleetCmdGetOutput("-strict-host-key-checking=false", "list-unit-files", "-no-legend", "-fields", "unit")
+	//	units, _, err := e.RunFleetCmdGetOutput("list-unit-files", "-no-legend", "-fields", "unit")
 	//	if err != nil {
 	//		e.log.WithError(err).Fatal("Cannot list unit files")
 	//	}
@@ -65,7 +65,7 @@ func (e Env) concurrentChecker(services []string) {
 //
 //	e.Generate()
 //
-//	units, _, err := e.RunFleetCmdGetOutput("-strict-host-key-checking=false", "list-unit-files", "-no-legend", "-fields", "unit")
+//	units, _, err := e.RunFleetCmdGetOutput("list-unit-files", "-no-legend", "-fields", "unit")
 //	if err != nil {
 //		e.log.WithError(err).Fatal("Cannot list unit files")
 //	}

--- a/work/service.go
+++ b/work/service.go
@@ -159,7 +159,7 @@ func (s *Service) ListUnits() []string {
 }
 
 func (s *Service) GetFleetUnitContent(unit string) (string, error) { //TODO this method should be in unit
-	stdout, stderr, err := s.env.RunFleetCmdGetOutput("-strict-host-key-checking=false", "cat", unit)
+	stdout, stderr, err := s.env.RunFleetCmdGetOutput("cat", unit)
 	if err != nil && stderr == "Unit "+unit+" not found" {
 		return "", nil
 	}
@@ -167,7 +167,7 @@ func (s *Service) GetFleetUnitContent(unit string) (string, error) { //TODO this
 }
 
 func (s *Service) FleetListUnits(command string) {
-	stdout, _, err := s.env.RunFleetCmdGetOutput("-strict-host-key-checking=false", "list-units", "--full", "--no-legend")
+	stdout, _, err := s.env.RunFleetCmdGetOutput("list-units", "--full", "--no-legend")
 	if err != nil {
 		logs.WithEF(err, s.fields).Fatal("Failed to list-units")
 	}


### PR DESCRIPTION
So... ggn won't work if I run fleetctl 1.0.0.
This PR corrects 2 problems : 
 - calls to `fleetctl` with the `-strict-host-key-checking` flag, use env vars instead ;
 - override default driver to be `etcd` instead of the current [fleet API](https://coreos.com/fleet/docs/latest/api-v1.html)